### PR TITLE
Bump Clang CI matrix: promote 22 to primary, add 21 to secondary

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -63,7 +63,7 @@ jobs:
             }
           ],
           "clang": [
-            { "versions": ["21"],
+            { "versions": ["22"],
               "tests": [
                 {"cxxversions": ["c++26"],
                   "tests": [
@@ -82,7 +82,7 @@ jobs:
                 }
               ]
             },
-            { "versions": ["20", "19"],
+            { "versions": ["21", "20", "19"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23"],
                   "tests": [


### PR DESCRIPTION
## Summary
- Promote Clang 22 to primary CI version (full test suite)
- Demote Clang 21 to secondary tier alongside 20 and 19 (Release.Default only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)